### PR TITLE
Fix broken no_activity_max_age method.

### DIFF
--- a/awsbigbrother/report.py
+++ b/awsbigbrother/report.py
@@ -59,14 +59,14 @@ class ActionRunner(object):
     def check_no_rotation_since_days(self, max_age, check_list):
         row = self.row
         for attribute_name in check_list:
-            if self.row_active(row, attribute_name):
+            if self.attribute_active_for_row(row, attribute_name):
                 timestamp = getattr(row, "{0}_last_rotated".format(attribute_name))
                 if self.is_used(timestamp):
                     return self.is_older_than_days(timestamp, max_age)
         return False
 
     @classmethod
-    def row_active(cls, row, attribute_name):
+    def attribute_active_for_row(cls, row, attribute_name):
         row_is_active = getattr(row, "{0}_active".format(attribute_name))
         return cls.is_used(row_is_active)
 
@@ -74,20 +74,20 @@ class ActionRunner(object):
     def is_used(cls, attribute):
         return not (attribute == 'false' or attribute == 'N/A' or attribute == 'not_supported')
 
+
+
     def no_activity_max_age(self):
         row = self.row
-        attr_list = ['password', 'access_key_1', 'access_key_2']
-        no_activity = False
+        attr_list = ['password','access_key_1', 'access_key_2']
+        activity = False
         for attr in attr_list:
-            if self.row_active(row, attr):
-                attr_last_used = getattr(row, "{0}_last_used".format(attr))
-                if attr_last_used == 'no_information':
-                    attr_last_used = row.user_creation_time
-                max_age = self.config.no_activity_max_age
-                if self.is_older_than_days(attr_last_used, max_age):
-                    no_activity = True
-        return CheckResponse('no_activity_max_age', not no_activity,
-                             self.row.user).get_response()
+            if self.attribute_active_for_row(row, attr):
+                attr_last_used  = getattr(row,"{0}_last_used".format(attr))
+                if attr_last_used != 'no_information':
+                    max_age = self.config.no_activity_max_age
+                    if not self.is_older_than_days(attr_last_used, max_age):
+                        activity = True
+        return CheckResponse('no_activity_max_age', activity, self.row.user).get_response()
 
     @classmethod
     def is_older_than_days(cls, timestamp, max_age):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -17,7 +17,6 @@ class TestCli(object):
             assert isinstance(result.exception, SystemExit)
             assert "mfa failed for user" in result.output
 
-
     def test_without_mfa(self, vcr_test):
         with vcr_test.use_cassette('config_load_test.yml'):
             runner = CliRunner()

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -75,7 +75,7 @@ class TestReportActionRunner(object):
     def test_row_active(self):
         row_array = self.row.format('2016').split(',')
         cred_report_row = ReportRow(row_array)
-        active = ActionRunner.row_active(cred_report_row, 'password')
+        active = ActionRunner.attribute_active_for_row(cred_report_row, 'password')
         assert active
 
     def test_check_no_rotation_since_days(self, action_runner):


### PR DESCRIPTION
Previously it would show false positives if a user had only one
attribute that was out of date. No activity max age is supposed to only
alert if the user has not done anything in n days.